### PR TITLE
Gain table support in libbladerf python binding

### DIFF
--- a/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
@@ -608,7 +608,15 @@ class BladeRF:
         _check_error(ret)
 
     # Gain
-
+    def set_gain_calibration(self, ch, path):
+        ret = libbladeRF.bladerf_load_gain_calibration(self.dev[0], ch, path.encode())
+        _check_error(ret)
+        return ret
+    def enable_gain_calibration(self, ch, enable):
+        ret = libbladeRF.bladerf_enable_gain_calibration(self.dev[0], ch, enable)
+        _check_error(ret)
+        return ret
+    
     def set_gain(self, ch, gain):
         ret = libbladeRF.bladerf_set_gain(self.dev[0], ch, gain)
         _check_error(ret)
@@ -1138,7 +1146,7 @@ class BladeRF:
         @gain.setter
         def gain(self, value):
             return self.dev.set_gain(self.channel, value)
-
+        
         @property
         def gain_mode(self):
             """Gain mode"""
@@ -1241,6 +1249,14 @@ class BladeRF:
 
         def set_enable(self, value):
             return self.dev.enable_module(self.channel, value)
+
+        def load_gain_table (self, csv_path):
+            return self.dev.set_gain_calibration(self.channel, csv_path)
+
+
+        def enable_gain_table(self, ch, en):
+            return self.dev.enable_gain_calibration((self.channel, en))
+
 
         enable = property(fset=set_enable, doc="Enable/disable RF chain")
 

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_bladerf.py
@@ -617,6 +617,12 @@ class BladeRF:
         _check_error(ret)
         return ret
     
+    def get_gain_calibration(self, ch):
+        gain = ffi.new("int *")
+        ret = libbladeRF.bladerf_get_gain_target(self.dev[0], ch, gain)
+        _check_error(ret)
+        return gain[0]
+    
     def set_gain(self, ch, gain):
         ret = libbladeRF.bladerf_set_gain(self.dev[0], ch, gain)
         _check_error(ret)
@@ -1142,7 +1148,12 @@ class BladeRF:
         def gain(self):
             """Gain, in dB"""
             return self.dev.get_gain(self.channel)
-
+        
+        @property
+        def gain_target(self):
+            "Computes the gain target for a specified channel, incorporating calibration corrections."
+            return self.dev.get_gain_calibration(self.channel)
+        
         @gain.setter
         def gain(self, value):
             return self.dev.set_gain(self.channel, value)

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_cdef.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_cdef.py
@@ -149,6 +149,10 @@ header = """
     const char *stage, bladerf_gain gain);
   int bladerf_get_gain_stage(struct bladerf *dev, bladerf_channel ch,
     const char *stage, bladerf_gain *gain);
+  int bladerf_load_gain_calibration(struct bladerf *dev, bladerf_channel ch,
+        const char* cal_file_loc);
+  int bladerf_enable_gain_calibration(struct bladerf *dev, bladerf_channel ch,
+        bool en);
   int bladerf_get_gain_stage_range(struct bladerf *dev, bladerf_channel
     ch, const char *stage, const struct bladerf_range **range);
   int bladerf_get_gain_stages(struct bladerf *dev, bladerf_channel ch,

--- a/host/libraries/libbladeRF_bindings/python/bladerf/_cdef.py
+++ b/host/libraries/libbladeRF_bindings/python/bladerf/_cdef.py
@@ -153,6 +153,8 @@ header = """
         const char* cal_file_loc);
   int bladerf_enable_gain_calibration(struct bladerf *dev, bladerf_channel ch,
         bool en);
+  int bladerf_get_gain_target(struct bladerf *dev, bladerf_channel ch, 
+        int *gain_target);
   int bladerf_get_gain_stage_range(struct bladerf *dev, bladerf_channel
     ch, const char *stage, const struct bladerf_range **range);
   int bladerf_get_gain_stages(struct bladerf *dev, bladerf_channel ch,

--- a/host/libraries/libbladeRF_bindings/python/setup.py
+++ b/host/libraries/libbladeRF_bindings/python/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='bladerf',
-    version='1.3.0',
+    version='1.3.1',
     description='CFFI-based Python 3 binding to libbladeRF',
     long_description=long_description,
     url='https://github.com/Nuand/bladeRF',


### PR DESCRIPTION
Add new gain table calibration functions to the python version of libbladeRF. Needed to generate our gain table using the Rhode siggen.