### PR TITLE
Dev/reset sync timestamp

### DIFF
--- a/host/libraries/libbladeRF/include/libbladeRF.h
+++ b/host/libraries/libbladeRF/include/libbladeRF.h
@@ -2781,6 +2781,9 @@ int CALL_CONV bladerf_sync_config(struct bladerf *dev,
                                   unsigned int num_transfers,
                                   unsigned int stream_timeout);
 
+API_EXPORT
+int CALL_CONV bladerf_sync_reset_timestamp(struct bladerf *dev,
+                                         bladerf_direction dir);                                  
 /**
  * Transmit IQ samples.
  *

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -1248,7 +1248,7 @@ int bladerf_sync_rx(struct bladerf *dev,
 }
 
 int bladerf_sync_reset_timestamp(struct bladerf *dev,
-                                 bladerf_direction dir`)
+                                 bladerf_direction dir)
 {
     int status;
     MUTEX_LOCK(&dev->lock);

--- a/host/libraries/libbladeRF/src/bladerf.c
+++ b/host/libraries/libbladeRF/src/bladerf.c
@@ -1247,6 +1247,17 @@ int bladerf_sync_rx(struct bladerf *dev,
     return dev->board->sync_rx(dev, samples, num_samples, metadata, timeout_ms);
 }
 
+int bladerf_sync_reset_timestamp(struct bladerf *dev,
+                                 bladerf_direction dir`)
+{
+    int status;
+    MUTEX_LOCK(&dev->lock);
+
+    status = dev->board->sync_reset_timestamp(dev, dir);
+
+    MUTEX_UNLOCK(&dev->lock);
+    return status;
+}
 int bladerf_get_timestamp(struct bladerf *dev,
                           bladerf_direction dir,
                           bladerf_timestamp *timestamp)

--- a/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
+++ b/host/libraries/libbladeRF/src/board/bladerf2/bladerf2.c
@@ -2201,6 +2201,14 @@ static int bladerf2_sync_config(struct bladerf *dev,
     return status;
 }
 
+static int bladerf2_sync_reset_timestamp(struct bladerf *dev,
+                                     bladerf_direction dir)
+{
+    CHECK_BOARD_STATE(STATE_INITIALIZED);
+    struct bladerf2_board_data *board_data = dev->board_data;
+    return sync_reset_timestamp(&board_data->sync[dir]);
+}
+
 static int bladerf2_sync_tx(struct bladerf *dev,
                             void const *samples,
                             unsigned int num_samples,
@@ -2951,6 +2959,7 @@ struct board_fns const bladerf2_board_fns = {
     FIELD_INIT(.set_stream_timeout, bladerf2_set_stream_timeout),
     FIELD_INIT(.get_stream_timeout, bladerf2_get_stream_timeout),
     FIELD_INIT(.sync_config, bladerf2_sync_config),
+    FIELD_INIT(.sync_reset_timestamp, bladerf2_sync_reset_timestamp),
     FIELD_INIT(.sync_tx, bladerf2_sync_tx),
     FIELD_INIT(.sync_rx, bladerf2_sync_rx),
     FIELD_INIT(.get_timestamp, bladerf2_get_timestamp),

--- a/host/libraries/libbladeRF/src/board/board.h
+++ b/host/libraries/libbladeRF/src/board/board.h
@@ -398,6 +398,8 @@ struct board_fns {
                    unsigned int num_samples,
                    struct bladerf_metadata *metadata,
                    unsigned int timeout_ms);
+    int (*sync_reset_timestamp)(struct bladerf *dev,
+                                bladerf_direction dir);
     int (*get_timestamp)(struct bladerf *dev,
                          bladerf_direction dir,
                          bladerf_timestamp *timestamp);

--- a/host/libraries/libbladeRF/src/streaming/sync.c
+++ b/host/libraries/libbladeRF/src/streaming/sync.c
@@ -1053,6 +1053,24 @@ static inline int handle_tx_parameters(struct bladerf_metadata *user_meta,
     return 0;
 }
 
+int sync_reset_timestamp(struct bladerf_sync *sync)
+{
+    int status = 0;
+
+    if (sync == NULL || !sync->initialized) {
+        return BLADERF_ERR_INVAL;
+    }
+
+    MUTEX_LOCK(&sync->lock);
+
+    sync->meta.curr_timestamp = 0;
+
+    MUTEX_UNLOCK(&sync->lock);
+
+    return status;
+
+}
+
 int sync_tx(struct bladerf_sync *s,
             void const *samples,
             unsigned int num_samples,

--- a/host/libraries/libbladeRF/src/streaming/sync.h
+++ b/host/libraries/libbladeRF/src/streaming/sync.h
@@ -252,10 +252,15 @@ int sync_tx(struct bladerf_sync *sync,
             struct bladerf_metadata *metadata,
             unsigned int timeout_ms);
 
+int sync_reset_timestamp(struct bladerf_sync *sync);
+
 unsigned int sync_buf2idx(struct buffer_mgmt *b, void *addr);
 
 void *sync_idx2buf(struct buffer_mgmt *b, unsigned int idx);
 
 int sync_prime_stream(struct bladerf_sync *sync, unsigned int timeout_ms);
+
+int sync_reset_timestamp(struct bladerf_sync *sync,
+                            bladerf_direction dir);
 
 #endif

--- a/host/libraries/libbladeRF/src/streaming/sync.h
+++ b/host/libraries/libbladeRF/src/streaming/sync.h
@@ -260,7 +260,5 @@ void *sync_idx2buf(struct buffer_mgmt *b, unsigned int idx);
 
 int sync_prime_stream(struct bladerf_sync *sync, unsigned int timeout_ms);
 
-int sync_reset_timestamp(struct bladerf_sync *sync,
-                            bladerf_direction dir);
 
 #endif


### PR DESCRIPTION
Add a public api to reset a piece of state in the sync object that prevents scheduled TX from working if the module is disabled and reenabled.